### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity to the extracurricular activities signup system.

## Fixes
Closes #6

## Changes Made
- Added "GitHub Skills" activity to the activities dictionary
- Set schedule to Mondays and Thursdays, 3:30 PM - 5:00 PM
- Maximum capacity: 25 students
- Includes description highlighting it's part of the GitHub Certifications program

## Context
The principal announced this partnership with GitHub in the school assembly, and students have been unable to find it on the signup page. This activity will teach practical coding and collaboration skills and is part of the GitHub Certifications program to help with college applications.

## Testing
- [x] Verified the activity appears in the activities list
- [x] Confirmed students can sign up for the activity
- [x] Registration closes by the end of this week as mentioned in the issue